### PR TITLE
Add Word Replacements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export interface TransactionDescriptor {
 export default class EasyCopyPaste {
     private readonly specialDelimiters;
     private mapCache;
+    private readonly wordReplacements;
     /**
      * Method to convert item names into easily copy-pasteable strings.
      *
@@ -35,6 +36,14 @@ export default class EasyCopyPaste {
      * @returns {TransactionDescriptor} Object which contains the original item name and the command type for checkout.
      */
     fromEasyCopyPasteString(str: string): TransactionDescriptor;
+    /**
+     * Method to replace long words with shortened versions and vice versa.
+     *
+     * @param {string} str The input string.
+     * @param {boolean} shorten Whether to shorten or lengthen the words.
+     * @returns {string} The modified string with long/short words replaced.
+     */
+    private replaceLongWords;
     private findMappedValue;
     private defaultChars;
     private boldChars;

--- a/index.js
+++ b/index.js
@@ -2,12 +2,12 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 class EasyCopyPaste {
     constructor() {
-        this.specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`, ','];
+        this.specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`, `,`];
         this.mapCache = new Array();
         this.wordReplacements = Object.fromEntries([
-            ["Killstreak", "Ks"],
-            ["Professional", "Pro"],
-            ["Specialized", "Spec"]
+            ['Killstreak', 'Ks'],
+            ['Professional', 'Pro'],
+            ['Specialized', 'Spec']
         ]);
         this.defaultChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
         this.boldChars = '𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵';

--- a/index.js
+++ b/index.js
@@ -4,12 +4,12 @@ class EasyCopyPaste {
     constructor() {
         this.specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`];
         this.mapCache = new Array();
-        this.wordReplacements = {
-            'Mann Co. Supply Crate Key': 'key',
-            "Killstreak": "ks",
-            "Professional": "pro",
-            "Specialized": "spec",
-        };
+        this.wordReplacements = Object.fromEntries([
+            ["Mann Co. Supply Crate Key", "Key"],
+            ["Killstreak", "Ks"],
+            ["Professional", "Pro"],
+            ["Specialized", "Spec"]
+        ]);
         this.defaultChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
         this.boldChars = '𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵';
     }
@@ -66,12 +66,9 @@ class EasyCopyPaste {
      */
     replaceLongWords(str, shorten) {
         // Replace words with their shortened or lengthened versions
-        for (const word in this.wordReplacements) {
-            if (Object.prototype.hasOwnProperty.call(this.wordReplacements, word)) {
-                const replacementWord = shorten ? this.wordReplacements[word] : word;
-                const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
-                str = str.replace(wordRegex, replacementWord);
-            }
+        for (const [word, replacementWord] of Object.entries(this.wordReplacements)) {
+            const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
+            str = str.replace(wordRegex, shorten ? replacementWord : word);
         }
         return str;
     }
@@ -123,6 +120,7 @@ class EasyCopyPaste {
         if (found !== null) {
             return found.mappedName;
         }
+        const originalStr = str;
         // Replace long words with shortened versions
         str = this.replaceLongWords(str, true);
         let shouldSave = false;
@@ -142,7 +140,7 @@ class EasyCopyPaste {
             char = strArr[i];
         }
         const mapped = {
-            itemName: str,
+            itemName: originalStr,
             mappedName: strArr.join('')
         };
         if (shouldSave) {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,12 @@ class EasyCopyPaste {
     constructor() {
         this.specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`];
         this.mapCache = new Array();
+        this.wordReplacements = {
+            'Mann Co. Supply Crate Key': 'key',
+            "Killstreak": "ks",
+            "Professional": "pro",
+            "Specialized": "spec",
+        };
         this.defaultChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
         this.boldChars = '𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵';
     }
@@ -51,6 +57,24 @@ class EasyCopyPaste {
             command: cmd
         };
     }
+    /**
+     * Method to replace long words with shortened versions and vice versa.
+     *
+     * @param {string} str The input string.
+     * @param {boolean} shorten Whether to shorten or lengthen the words.
+     * @returns {string} The modified string with long/short words replaced.
+     */
+    replaceLongWords(str, shorten) {
+        // Replace words with their shortened or lengthened versions
+        for (const word in this.wordReplacements) {
+            if (Object.prototype.hasOwnProperty.call(this.wordReplacements, word)) {
+                const replacementWord = shorten ? this.wordReplacements[word] : word;
+                const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
+                str = str.replace(wordRegex, replacementWord);
+            }
+        }
+        return str;
+    }
     findMappedValue(str, mappedItems) {
         const lowerStr = str.toLowerCase();
         return mappedItems.find((item) => {
@@ -90,13 +114,17 @@ class EasyCopyPaste {
         if (found !== null) {
             return found.itemName;
         }
-        return str.replace(/_/g, ' ');
+        // Replace shortened words with long words
+        let clear = str.replace(/_/g, ' ');
+        return this.replaceLongWords(clear, false);
     }
     mapString(str) {
         const found = this.findMappedValue(str, this.mapCache);
         if (found !== null) {
             return found.mappedName;
         }
+        // Replace long words with shortened versions
+        str = this.replaceLongWords(str, true);
         let shouldSave = false;
         const easyDelimiter = '_';
         const strArr = str.split('');

--- a/index.js
+++ b/index.js
@@ -67,8 +67,9 @@ class EasyCopyPaste {
     replaceLongWords(str, shorten) {
         // Replace words with their shortened or lengthened versions
         for (const [word, replacementWord] of Object.entries(this.wordReplacements)) {
-            const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
-            str = str.replace(wordRegex, shorten ? replacementWord : word);
+            const escapedWord = word.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'); // Escape special characters
+            const wordRegex = new RegExp(`\\b${escapedWord.replace(/ /g, '\\s')}\\b`, 'gi');
+            str = str.replace(wordRegex, (match) => shorten ? replacementWord : match);
         }
         return str;
     }

--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ class EasyCopyPaste {
         this.specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`, `,`];
         this.mapCache = new Array();
         this.wordReplacements = Object.fromEntries([
-            ['Killstreak', 'Ks'],
-            ['Professional', 'Pro'],
-            ['Specialized', 'Spec']
+            ['Professional Killstreak', 'Pro Ks'],
+            ['Specialized Killstreak', 'Spec Ks'],
+            ['Killstreak', 'Ks']
         ]);
         this.defaultChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
         this.boldChars = '𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵';
@@ -64,10 +64,12 @@ class EasyCopyPaste {
      * @returns {string} The modified string with long/short words replaced.
      */
     replaceLongWords(str, shorten) {
-        // Replace words with their shortened or lengthened versions
-        for (const [word, replacementWord] of Object.entries(this.wordReplacements)) {
-            const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
-            str = str.replace(wordRegex, shorten ? replacementWord : word);
+        const replacements = Object.entries(this.wordReplacements)
+            .sort((a, b) => b[0].length - a[0].length);
+        // Replace phrases with their shortened or lengthened versions
+        for (const [phrase, replacementPhrase] of replacements) {
+            const phraseRegex = new RegExp(`\\b${phrase}\\b`, 'gi');
+            str = str.replace(phraseRegex, shorten ? replacementPhrase : phrase);
         }
         return str;
     }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ class EasyCopyPaste {
         this.specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`];
         this.mapCache = new Array();
         this.wordReplacements = Object.fromEntries([
-            ["Mann Co. Supply Crate Key", "Key"],
             ["Killstreak", "Ks"],
             ["Professional", "Pro"],
             ["Specialized", "Spec"]
@@ -67,9 +66,8 @@ class EasyCopyPaste {
     replaceLongWords(str, shorten) {
         // Replace words with their shortened or lengthened versions
         for (const [word, replacementWord] of Object.entries(this.wordReplacements)) {
-            const escapedWord = word.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'); // Escape special characters
-            const wordRegex = new RegExp(`\\b${escapedWord.replace(/ /g, '\\s')}\\b`, 'gi');
-            str = str.replace(wordRegex, (match) => shorten ? replacementWord : match);
+            const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
+            str = str.replace(wordRegex, shorten ? replacementWord : word);
         }
         return str;
     }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 class EasyCopyPaste {
     constructor() {
-        this.specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`];
+        this.specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`, ','];
         this.mapCache = new Array();
         this.wordReplacements = Object.fromEntries([
             ["Killstreak", "Ks"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ export default class EasyCopyPaste {
     private readonly specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`];
     private mapCache: MappedItem[] = new Array();
     private readonly wordReplacements = Object.fromEntries([
-        ["Mann Co. Supply Crate Key", "Key"],
         ["Killstreak", "Ks"],
         ["Professional", "Pro"],
         ["Specialized", "Spec"]
@@ -77,12 +76,10 @@ export default class EasyCopyPaste {
     private replaceLongWords(str: string, shorten: boolean): string {
         // Replace words with their shortened or lengthened versions
         for (const [word, replacementWord] of Object.entries(this.wordReplacements)) {
-            const escapedWord = word.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'); // Escape special characters
-            const wordRegex = new RegExp(`\\b${escapedWord.replace(/ /g, '\\s')}\\b`, 'gi');
-            str = str.replace(wordRegex, (match) =>
-                shorten ? replacementWord : match
-            );
+            const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
+            str = str.replace(wordRegex, shorten ? replacementWord : word);
         }
+
         return str;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,12 @@ export interface TransactionDescriptor {
 }
 
 export default class EasyCopyPaste {
-    private readonly specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`, ','];
+    private readonly specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`, `,`];
     private mapCache: MappedItem[] = new Array();
     private readonly wordReplacements = Object.fromEntries([
-        ["Killstreak", "Ks"],
-        ["Professional", "Pro"],
-        ["Specialized", "Spec"]
+        ['Killstreak', 'Ks'],
+        ['Professional', 'Pro'],
+        ['Specialized', 'Spec']
     ]);
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,12 @@ export interface TransactionDescriptor {
 export default class EasyCopyPaste {
     private readonly specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`];
     private mapCache: MappedItem[] = new Array();
-    private readonly wordReplacements: Record<string, string> = {
-        'Mann Co. Supply Crate Key': 'key',
-        "Killstreak": "ks",
-        "Professional": "pro",
-        "Specialized": "spec",
-    };
+    private readonly wordReplacements = Object.fromEntries([
+        ["Mann Co. Supply Crate Key", "Key"],
+        ["Killstreak", "Ks"],
+        ["Professional", "Pro"],
+        ["Specialized", "Spec"]
+    ]);
 
     /**
      * Method to convert item names into easily copy-pasteable strings.
@@ -76,13 +76,11 @@ export default class EasyCopyPaste {
      */
     private replaceLongWords(str: string, shorten: boolean): string {
         // Replace words with their shortened or lengthened versions
-        for (const word in this.wordReplacements) {
-            if (Object.prototype.hasOwnProperty.call(this.wordReplacements, word)) {
-                const replacementWord = shorten ? this.wordReplacements[word] : word;
-                const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
-                str = str.replace(wordRegex, replacementWord);
-            }
+        for (const [word, replacementWord] of Object.entries(this.wordReplacements)) {
+            const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
+            str = str.replace(wordRegex, shorten ? replacementWord : word);
         }
+
         return str;
     }
 
@@ -149,7 +147,7 @@ export default class EasyCopyPaste {
         if (found !== null) {
             return found.mappedName;
         }
-
+        const originalStr = str;
         // Replace long words with shortened versions
         str = this.replaceLongWords(str, true);
 
@@ -173,7 +171,7 @@ export default class EasyCopyPaste {
         }
     
         const mapped = {
-            itemName: str,
+            itemName: originalStr,
             mappedName: strArr.join('')
         } as MappedItem;
     

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,12 @@ export interface TransactionDescriptor {
 export default class EasyCopyPaste {
     private readonly specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`];
     private mapCache: MappedItem[] = new Array();
+    private readonly wordReplacements: Record<string, string> = {
+        'Mann Co. Supply Crate Key': 'key',
+        "Killstreak": "ks",
+        "Professional": "pro",
+        "Specialized": "spec",
+    };
 
     /**
      * Method to convert item names into easily copy-pasteable strings.
@@ -59,6 +65,25 @@ export default class EasyCopyPaste {
             itemName: this.reverseMapString(clear),
             command: cmd
         } as TransactionDescriptor;
+    }
+
+    /**
+     * Method to replace long words with shortened versions and vice versa.
+     *
+     * @param {string} str The input string.
+     * @param {boolean} shorten Whether to shorten or lengthen the words.
+     * @returns {string} The modified string with long/short words replaced.
+     */
+    private replaceLongWords(str: string, shorten: boolean): string {
+        // Replace words with their shortened or lengthened versions
+        for (const word in this.wordReplacements) {
+            if (Object.prototype.hasOwnProperty.call(this.wordReplacements, word)) {
+                const replacementWord = shorten ? this.wordReplacements[word] : word;
+                const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
+                str = str.replace(wordRegex, replacementWord);
+            }
+        }
+        return str;
     }
 
     private findMappedValue(str: string, mappedItems: MappedItem[]): MappedItem | null {
@@ -114,7 +139,9 @@ export default class EasyCopyPaste {
             return found.itemName;
         }
 
-        return str.replace(/_/g, ' ');
+        // Replace shortened words with long words
+        let clear = str.replace(/_/g, ' ');
+        return this.replaceLongWords(clear, false);
     }
 
     private mapString(str: string): string {
@@ -122,7 +149,10 @@ export default class EasyCopyPaste {
         if (found !== null) {
             return found.mappedName;
         }
-    
+
+        // Replace long words with shortened versions
+        str = this.replaceLongWords(str, true);
+
         let shouldSave = false;
         const easyDelimiter = '_';
         const strArr = str.split('');

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,10 +77,12 @@ export default class EasyCopyPaste {
     private replaceLongWords(str: string, shorten: boolean): string {
         // Replace words with their shortened or lengthened versions
         for (const [word, replacementWord] of Object.entries(this.wordReplacements)) {
-            const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
-            str = str.replace(wordRegex, shorten ? replacementWord : word);
+            const escapedWord = word.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'); // Escape special characters
+            const wordRegex = new RegExp(`\\b${escapedWord.replace(/ /g, '\\s')}\\b`, 'gi');
+            str = str.replace(wordRegex, (match) =>
+                shorten ? replacementWord : match
+            );
         }
-
         return str;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,9 @@ export default class EasyCopyPaste {
     private readonly specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`, `,`];
     private mapCache: MappedItem[] = new Array();
     private readonly wordReplacements = Object.fromEntries([
-        ['Killstreak', 'Ks'],
-        ['Professional', 'Pro'],
-        ['Specialized', 'Spec']
+        ['Professional Killstreak', 'Pro Ks'],
+        ['Specialized Killstreak', 'Spec Ks'],
+        ['Killstreak', 'Ks']
     ]);
 
     /**
@@ -74,12 +74,14 @@ export default class EasyCopyPaste {
      * @returns {string} The modified string with long/short words replaced.
      */
     private replaceLongWords(str: string, shorten: boolean): string {
-        // Replace words with their shortened or lengthened versions
-        for (const [word, replacementWord] of Object.entries(this.wordReplacements)) {
-            const wordRegex = new RegExp(`\\b${word}\\b`, 'gi');
-            str = str.replace(wordRegex, shorten ? replacementWord : word);
-        }
+        const replacements = Object.entries(this.wordReplacements)
+            .sort((a, b) => b[0].length - a[0].length);
 
+        // Replace phrases with their shortened or lengthened versions
+        for (const [phrase, replacementPhrase] of replacements) {
+            const phraseRegex = new RegExp(`\\b${phrase}\\b`, 'gi');
+            str = str.replace(phraseRegex, shorten ? replacementPhrase : phrase);
+        }
         return str;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export interface TransactionDescriptor {
 }
 
 export default class EasyCopyPaste {
-    private readonly specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`];
+    private readonly specialDelimiters = [` `, `'`, `-`, `/`, `.`, `#`, `!`, `:`, `(`, `)`, ','];
     private mapCache: MappedItem[] = new Array();
     private readonly wordReplacements = Object.fromEntries([
         ["Killstreak", "Ks"],


### PR DESCRIPTION
Adds word replacements for abbreviating and expanding certain words making the commands generally shorter. These replacements are defined in the `wordReplacements` map.

Example Usage:
- Instead of "!buy Strange Killstreak Huo-Long Heater" to buy_Strange_Specialized_Killstreak_Huo_Long_Heater, its now buy_Strange_Spec_Ks_Huo_Long_Heater
